### PR TITLE
force mute to display on all devices, from videojs/video.js#4478

### DIFF
--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -4,7 +4,6 @@
 import Button from '../button';
 import Component from '../component';
 import * as Dom from '../utils/dom.js';
-import checkVolumeSupport from './volume-control/check-volume-support';
 
 /**
  * A button component for muting the audio.
@@ -24,9 +23,6 @@ class MuteToggle extends Button {
    */
   constructor(player, options) {
     super(player, options);
-
-    // hide this control if volume support is missing
-    checkVolumeSupport(this, player);
 
     this.on(player, ['loadstart', 'volumechange'], this.update);
   }

--- a/src/js/control-bar/volume-panel.js
+++ b/src/js/control-bar/volume-panel.js
@@ -2,7 +2,6 @@
  * @file volume-control.js
  */
 import Component from '../component.js';
-import checkVolumeSupport from './volume-control/check-volume-support';
 import {isPlain} from '../utils/obj';
 
 // Required children
@@ -41,9 +40,6 @@ class VolumePanel extends Component {
     }
 
     super(player, options);
-
-    // hide this control if volume support is missing
-    checkVolumeSupport(this, player);
 
     // while the slider is active (the mouse has been pressed down and
     // is dragging) we do not want to hide the VolumeBar


### PR DESCRIPTION
Workaround for a [reported bug]( https://github.com/videojs/video.js/issues/4478) in the video.js library, affecting iOS mobile-web, causing the mute button not to display.

This is because [IOS does not allow programatic control of volume](https://stackoverflow.com/questions/2602541/html5-video-volume#4816050)

However, videojs conflates `volume` support with `muted` support, and these are not actually the same. Muting works independent of volume (so that you can unmute with the same volume level). IOS supports muting. 

This PR opts to _always_ display the volume-control panel and mute button. (The volume slider will continue to display only when there is `volume` support -- and unfortunately there will be a tiny gap when it is hidden)

I think always displaying mute is the right move -- and I would hazard that if the browser/device doesn't even support muting, it probably doesn't support video period, and videojs would bonk much earlier.





## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
