### PR TITLE
Ads - Fix issue with attribute and property not syncing when fullscreen video

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1237,7 +1237,7 @@ Html5.resetMediaElement = function(el) {
   'playsinline'
 ].forEach(function(prop) {
   Html5.prototype[prop] = function() {
-    return this.el_[prop] || this.el_.hasAttribute(prop);
+    return this.el_[prop];
   };
 });
 


### PR DESCRIPTION
## Description
- videoJS fails to remove muted attr on the video element when in fullscreen on mobile web
- when that conditional ran, the second part would always return true so a mute / unmute event would never fire
- more of story history here https://github.com/doximity/doximity/pull/23388

## Specific Changes proposed
- only access the property element since everything listed in that array is a property, no need to check attribute too

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
